### PR TITLE
Issue with category "swallowing" pubDate in RSS2 generation

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -134,8 +134,8 @@ sub output_rss {
 				description => $item->{'body'},
 				author => $item->{'author'},
 				comments => "${link}#comments",
+				category => [split(/, */, $item->{'tags'})],
 				pubDate => POSIX::strftime("%a, %d %b %Y %H:%M:%S %Z", gmtime($item->{'epoch'})),
-				category => @{[split(/, */, $item->{'tags'})]},
 			);
 		} else {
 			$rss->add_item (


### PR DESCRIPTION
Hi,

I think I cornered the bug where the pubDate would sometimes disappear in some combination of tags and their number (and creating an “Odd number of elements in anonymous hash at /usr/local/libdata/perl5/site_perl/XML/RSS.pm line 399.” error).

It seems the array returned by split() when processing the tags list does not need to be dereferenced at the $rss->add_item() stage, but just copied (as is done with the [ ]).

I'm no Perl guru, and feeling thoroughly confused as to why _this_ works, and everything I tride before didn't, but hey, it works!

Also, re-order category before pubDate, as was the case prior to 6b87e3d1.

Tested with blogsum-1.1p1 OpenBSD 5.2.

Signed-off-by: Olivier Mehani shtrom@ssji.net
